### PR TITLE
Raise an error on empty code sections in complex strings

### DIFF
--- a/src/Compiler/Logging/Logger.cs
+++ b/src/Compiler/Logging/Logger.cs
@@ -213,13 +213,13 @@ public static class Logger
             case IValued<char> unxChar:
                 var chr = unxChar.Value;
                 if (chr is '\n' or '\r') {
-                    sb.Append("newline character.");
+                    sb.Append("newline character");
                 } else if (chr == '\t') {
-                    sb.Append("tabulation character.");
+                    sb.Append("tabulation character");
                 } else if (Char.IsWhiteSpace(chr)) {
                     sb.Append("whitespace character '" + System.Text.RegularExpressions.Regex.Escape(chr.ToString()));
                 } else {
-                    sb.Append("character '" + chr + "'.");
+                    sb.Append("character '" + chr + "'");
                 }
                 break;
             default:

--- a/src/Compiler/Syntax/Parslets/PrefixParslets/StringLiteralParslet.cs
+++ b/src/Compiler/Syntax/Parslets/PrefixParslets/StringLiteralParslet.cs
@@ -13,6 +13,8 @@ public sealed class StringLiteralParslet : IPrefixParslet<StringNode>
             var sections = ImmutableArray.CreateBuilder<ValueNode>(complexString.CodeSections.Length);
 
             foreach (var section in complexString.CodeSections) {
+                Debug.Assert(section.Length > 0);
+
                 var endPos = (section.LastOrDefault()?.Location ?? parser.Position).GetLastLocation();
 
                 var sectionConsumer = new Consumer<Token>(

--- a/src/Compiler/Syntax/Tokenizer.Toklets.cs
+++ b/src/Compiler/Syntax/Tokenizer.Toklets.cs
@@ -415,11 +415,22 @@ public partial class Tokenizer : IConsumer<Token>
                         tokenList.Add(currToken);
                 }
 
+                if (tokenList.Count > 0) {
+                    sections.Add(tokenList.ToImmutable());
+
+                    output.Append('{').Append(sections.Count - 1).Append('}');
+                } else {
+                    Logger.Error(new UnexpectedError<char>(ErrorArea.Tokenizer) {
+                        In = "an interpolated string",
+                        Value = '}',
+                        Expected = "an expression",
+                        Location = this.Position
+                    });
+
+                    isValid = false;
+                }
+
                 this.Reconsume();
-
-                sections.Add(tokenList.ToImmutable());
-
-                output.Append('{').Append(sections.Count - 1).Append('}');
 
                 if (this.Consume(preserveTrivia: true).TrailingTrivia != null) {
                     output.Append(this.Current.TrailingTrivia!.Representation);

--- a/src/Compiler/Syntax/Tokenizer.Toklets.cs
+++ b/src/Compiler/Syntax/Tokenizer.Toklets.cs
@@ -423,7 +423,8 @@ public partial class Tokenizer : IConsumer<Token>
                     Logger.Error(new UnexpectedError<char>(ErrorArea.Tokenizer) {
                         In = "an interpolated string",
                         Value = '}',
-                        Expected = "an expression",
+                        Expected = "a value",
+                        Message = "An interpolated section can't be empty.",
                         Location = this.Position
                     });
 


### PR DESCRIPTION
This PR fixes a crash on the following example :
```cs
print $"hello {} ! Today will be {GetWeather(pressure * 10.644^(temperature-2048))}";
```
However I'm not completely sure about the `Expected` field of the error : `an expression` might be a bit vague.

This PR also fixes the consistency of periods at the end of some sentences for `UnexpectedError<char>` since it produced invalid punctuation when used with the `In` field :
```console
Unexpected character '}'. in an interpolated string
```